### PR TITLE
Port of the prex FAT implementation

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -1,6 +1,12 @@
-config LIBFATFS
+menuconfig LIBFATFS
 	bool "fatfs: FAT filesystem"
 	default n
 	depends on LIBVFSCORE
 	depends on LIBUKBLKDEV
 	select LIBUKBLKDEV_SYNC_IO_BLOCKED_WAITING
+
+if LIBFATFS
+config LIBFATFS_DEBUG
+	bool "Debug messages"
+	default n
+endif

--- a/Config.uk
+++ b/Config.uk
@@ -1,0 +1,6 @@
+config LIBFATFS
+	bool "fatfs: FAT filesystem"
+	default n
+	depends on LIBVFSCORE
+	depends on LIBUKBLKDEV
+	select LIBUKBLKDEV_SYNC_IO_BLOCKED_WAITING

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -1,6 +1,7 @@
 $(eval $(call addlib_s,libfatfs,$(CONFIG_LIBFATFS)))
 
 LIBFATFS_CFLAGS-$(call gcc_version_ge,8,0) += -Wno-cast-function-type
+LIBFATFS_CFLAGS-$(CONFIG_LIBFATFS_DEBUG) += -DUK_DEBUG
 
 LIBFATFS_SRCS-y += $(LIBFATFS_BASE)/fatfs_vnops.c
 LIBFATFS_SRCS-y += $(LIBFATFS_BASE)/fatfs_node.c

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -1,0 +1,9 @@
+$(eval $(call addlib_s,libfatfs,$(CONFIG_LIBFATFS)))
+
+LIBFATFS_CFLAGS-$(call gcc_version_ge,8,0) += -Wno-cast-function-type
+
+LIBFATFS_SRCS-y += $(LIBFATFS_BASE)/fatfs_vnops.c
+LIBFATFS_SRCS-y += $(LIBFATFS_BASE)/fatfs_node.c
+LIBFATFS_SRCS-y += $(LIBFATFS_BASE)/fatfs_subr.c
+LIBFATFS_SRCS-y += $(LIBFATFS_BASE)/fatfs_fat.c
+LIBFATFS_SRCS-y += $(LIBFATFS_BASE)/fatfs_vfsops.c

--- a/fatfs.h
+++ b/fatfs.h
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2005-2007, Kohsuke Ohtani
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the author nor the names of any co-contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _FATFS_H
+#define _FATFS_H
+
+#include <sys/prex.h>
+#include <sys/cdefs.h>
+#include <sys/types.h>
+#include <sys/vnode.h>
+#include <sys/file.h>
+#include <sys/mount.h>
+#include <sys/syslog.h>
+#include <sys/buf.h>
+
+/* #define DEBUG_FATFS 1 */
+
+#ifdef DEBUG_FATFS
+#define DPRINTF(a)	dprintf a
+#define ASSERT(e)	dassert(e)
+#else
+#define DPRINTF(a)	do {} while (0)
+#define ASSERT(e)
+#endif
+
+
+#if CONFIG_FS_THREADS > 1
+#define malloc(s)		malloc_r(s)
+#define free(p)			free_r(p)
+#else
+#define mutex_init(m)		do {} while (0)
+#define mutex_destroy(m)	do {} while (0)
+#define mutex_lock(m)		do {} while (0)
+#define mutex_unlock(m)		do {} while (0)
+#define mutex_trylock(m)	do {} while (0)
+#endif
+
+
+#define SEC_SIZE	512		/* sector size */
+#define SEC_INVAL	0xffffffff	/* invalid sector */
+
+/*
+ * Pre-defined cluster number
+ */
+#define CL_ROOT		0		/* cluster 0 means the root directory */
+#define CL_FREE		0		/* cluster 0 also means the free cluster */
+#define CL_FIRST	2		/* first legal cluster */
+#define CL_LAST		0xfffffff5	/* last legal cluster */
+#define CL_EOF		0xffffffff	/* EOF cluster */
+
+#define EOF_MASK	0xfffffff8	/* mask of eof */
+
+#define FAT12_MASK	0x00000fff
+#define FAT16_MASK	0x0000ffff
+
+#if defined(__SUNPRO_C)
+#pragma pack(1)
+#endif
+
+/*
+ * BIOS parameter block
+ */
+struct fat_bpb {
+	uint16_t	jmp_instruction;
+	uint8_t		nop_instruction;
+	uint8_t		oem_id[8];
+	uint16_t	bytes_per_sector;
+	uint8_t		sectors_per_cluster;
+	uint16_t	reserved_sectors;
+	uint8_t		num_of_fats;
+	uint16_t	root_entries;
+	uint16_t	total_sectors;
+	uint8_t		media_descriptor;
+	uint16_t	sectors_per_fat;
+	uint16_t	sectors_per_track;
+	uint16_t	heads;
+	uint32_t	hidden_sectors;
+	uint32_t	big_total_sectors;
+	uint8_t		physical_drive;
+	uint8_t		reserved;
+	uint8_t		ext_boot_signature;
+	uint32_t	serial_no;
+	uint8_t		volume_id[11];
+	uint8_t		file_sys_id[8];
+} __packed;
+
+/*
+ * FAT directory entry
+ */
+struct fat_dirent {
+	uint8_t		name[11];
+	uint8_t		attr;
+	uint8_t		reserve[10];
+	uint16_t	time;
+	uint16_t	date;
+	uint16_t	cluster;
+	uint32_t	size;
+} __packed;
+
+#if defined(__SUNPRO_C)
+#pragma pack()
+#endif
+
+#define SLOT_EMPTY	0x00
+#define SLOT_DELETED	0xe5
+
+#define DIR_PER_SEC     (SEC_SIZE / sizeof(struct fat_dirent))
+
+/*
+ * FAT attribute for attr
+ */
+#define FA_RDONLY	0x01
+#define FA_HIDDEN	0x02
+#define FA_SYSTEM	0x04
+#define FA_VOLID	0x08
+#define FA_SUBDIR	0x10
+#define FA_ARCH		0x20
+#define FA_DEVICE	0x40
+
+#define IS_DIR(de)	(((de)->attr) & FA_SUBDIR)
+#define IS_VOL(de)	(((de)->attr) & FA_VOLID)
+#define IS_FILE(de)	(!IS_DIR(de) && !IS_VOL(de))
+
+#define IS_DELETED(de)  ((de)->name[0] == 0xe5)
+#define IS_EMPTY(de)    ((de)->name[0] == 0)
+
+/*
+ * Mount data
+ */
+struct fatfsmount {
+	int	fat_type;	/* 12 or 16 */
+	u_long	root_start;	/* start sector for root directory */
+	u_long	fat_start;	/* start sector for fat entries */
+	u_long	data_start;	/* start sector for data */
+	u_long	fat_eof;	/* id of end cluster */
+	u_long	sec_per_cl;	/* sectors per cluster */
+	u_long	cluster_size;	/* cluster size */
+	u_long	last_cluster;	/* last cluser */
+	u_long	fat_mask;	/* mask for cluster# */
+	u_long	free_scan;	/* start cluster# to free search */
+	vnode_t	root_vnode;	/* vnode for root */
+	char	*io_buf;	/* local data buffer */
+	char	*fat_buf;	/* buffer for fat entry */
+	char	*dir_buf;	/* buffer for directory entry */
+	dev_t	dev;		/* mounted device */
+#if CONFIG_FS_THREADS > 1
+	mutex_t lock;		/* file system lock */
+#endif
+};
+
+#define FAT12(fat)	((fat)->fat_type == 12)
+#define FAT16(fat)	((fat)->fat_type == 16)
+
+#define IS_EOFCL(fat, cl) \
+	(((cl) & EOF_MASK) == ((fat)->fat_mask & EOF_MASK))
+
+/*
+ * File/directory node
+ */
+struct fatfs_node {
+	struct fat_dirent dirent; /* copy of directory entry */
+	u_long	sector;		/* sector# for directory entry */
+	u_long	offset;		/* offset of directory entry in sector */
+};
+
+extern struct vnops fatfs_vnops;
+
+/* Macro to convert cluster# to logical sector# */
+#define cl_to_sec(fat, cl) \
+            (fat->data_start + (cl - 2) * fat->sec_per_cl)
+
+__BEGIN_DECLS
+int	 fat_next_cluster(struct fatfsmount *fmp, u_long cl, u_long *next);
+int	 fat_set_cluster(struct fatfsmount *fmp, u_long cl, u_long next);
+int	 fat_alloc_cluster(struct fatfsmount *fmp, u_long scan_start, u_long *free);
+int	 fat_free_clusters(struct fatfsmount *fmp, u_long start);
+int	 fat_seek_cluster(struct fatfsmount *fmp, u_long start, u_long offset,
+			    u_long *cl);
+int	 fat_expand_file(struct fatfsmount *fmp, u_long cl, int size);
+int	 fat_expand_dir(struct fatfsmount *fmp, u_long cl, u_long *new_cl);
+
+void	 fat_convert_name(char *org, char *name);
+void	 fat_restore_name(char *org, char *name);
+int	 fat_valid_name(char *name);
+int	 fat_compare_name(char *n1, char *n2);
+void	 fat_mode_to_attr(mode_t mode, u_char *attr);
+void	 fat_attr_to_mode(u_char attr, mode_t *mode);
+
+int	 fatfs_lookup_node(vnode_t dvp, char *name, struct fatfs_node *node);
+int	 fatfs_get_node(vnode_t dvp, int index, struct fatfs_node *node);
+int	 fatfs_put_node(struct fatfsmount *fmp, struct fatfs_node *node);
+int	 fatfs_add_node(vnode_t dvp, struct fatfs_node *node);
+__END_DECLS
+
+#endif /* !_FATFS_H */

--- a/fatfs.h
+++ b/fatfs.h
@@ -36,16 +36,7 @@
 #include <sys/mount.h>
 #include <stdint.h>
 
-/* #define DEBUG_FATFS 1 */
-
-#ifdef DEBUG_FATFS
 #define DPRINTF(a)	uk_pr_debug a
-#define ASSERT(e)	assert(e)
-#else
-#define DPRINTF(a)	do {} while (0)
-#define ASSERT(e)
-#endif
-
 
 #ifndef CONFIG_HAVE_SCHED
 #define uk_mutex_init(m)		do {} while (0)

--- a/fatfs.h
+++ b/fatfs.h
@@ -195,7 +195,7 @@ int	 fat_alloc_cluster(struct fatfsmount *fmp, __u32 scan_start, __u32 *free);
 int	 fat_free_clusters(struct fatfsmount *fmp, __u32 start);
 int	 fat_seek_cluster(struct fatfsmount *fmp, __u32 start, __u32 offset,
 			    __u32 *cl);
-int	 fat_expand_file(struct fatfsmount *fmp, __u32 cl, __u32 size);
+int	 fat_expand_file(struct fatfsmount *fmp, __u32 *cl, __u32 size);
 int	 fat_expand_dir(struct fatfsmount *fmp, __u32 cl, __u32 *new_cl);
 
 void	 fat_convert_name(char *org, char *name);

--- a/fatfs_fat.c
+++ b/fatfs_fat.c
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2005-2008, Kohsuke Ohtani
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the author nor the names of any co-contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/prex.h>
+#include <sys/buf.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "fatfs.h"
+
+/*
+ * Read the FAT entry for specified cluster.
+ */
+static int
+read_fat_entry(struct fatfsmount *fmp, u_long cl)
+{
+	u_long sec;
+	char *buf = fmp->fat_buf;
+	int error, border = 0;
+	struct buf *bp;
+
+	/* Get the sector number in FAT entry. */
+	if (FAT16(fmp))
+		sec = (cl * 2) / SEC_SIZE;
+	else {
+		sec = (cl * 3 / 2) / SEC_SIZE;
+		/*
+		 * Check if the entry data is placed at the
+		 * end of sector. If so, we have to read one
+		 * more sector to get complete FAT12 entry.
+		 */
+		if ((cl * 3 / 2) % SEC_SIZE == SEC_SIZE - 1)
+			border = 1;
+	}
+	sec += fmp->fat_start;
+
+	/* Read first sector. */
+	if ((error = bread(fmp->dev, sec, &bp)) != 0)
+		return error;
+	memcpy(buf, bp->b_data, SEC_SIZE);
+	brelse(bp);
+
+	if (!FAT12(fmp) || border == 0)
+		return 0;
+
+	/* Read second sector for the border entry of FAT12. */
+	if ((error = bread(fmp->dev, sec + 1, &bp)) != 0)
+		return error;
+	memcpy(buf + SEC_SIZE, bp->b_data, SEC_SIZE);
+	brelse(bp);
+	return 0;
+}
+
+/*
+ * Write fat entry from buffer.
+ */
+static int
+write_fat_entry(struct fatfsmount *fmp, u_long cl)
+{
+	u_long sec;
+	char *buf = fmp->fat_buf;
+	int error, border = 0;
+	struct buf *bp;
+
+	/* Get the sector number in FAT entry. */
+	if (FAT16(fmp))
+		sec = (cl * 2) / SEC_SIZE;
+	else {
+		sec = (cl * 3 / 2) / SEC_SIZE;
+		/* Check if border entry for FAT12 */
+		if ((cl * 3 / 2) % SEC_SIZE == SEC_SIZE - 1)
+			border = 1;
+	}
+	sec += fmp->fat_start;
+
+	/* Write first sector. */
+	bp = getblk(fmp->dev, sec);
+	memcpy(bp->b_data, buf, SEC_SIZE);
+	if ((error = bwrite(bp)) != 0)
+		return error;
+
+	if (!FAT12(fmp) || border == 0)
+		return 0;
+
+	/* Write second sector for the border entry of FAT12. */
+	bp = getblk(fmp->dev, sec + 1);
+	memcpy(bp->b_data, buf + SEC_SIZE, SEC_SIZE);
+	error = bwrite(bp);
+	return error;
+}
+
+/*
+ * Get next cluster number of FAT chain.
+ * @fmp: fat mount data
+ * @cl: previous cluster#
+ * @next: next cluster# to return
+ */
+int
+fat_next_cluster(struct fatfsmount *fmp, u_long cl, u_long *next)
+{
+	u_int offset;
+	uint16_t val;
+	int error;
+
+	/* Read FAT entry */
+	error = read_fat_entry(fmp, cl);
+	if (error)
+		return error;
+
+	/* Get offset in buffer. */
+	if (FAT16(fmp))
+		offset = (cl * 2) % SEC_SIZE;
+	else
+		offset = (cl * 3 / 2) % SEC_SIZE;
+
+	/* Pick up cluster# */
+	val = *((uint16_t *)(fmp->fat_buf + offset));
+
+	/* Adjust data for FAT12 entry */
+	if (FAT12(fmp)) {
+		if (cl & 1)
+			val >>= 4;
+		else
+			val &= 0xfff;
+	}
+	*next = (u_long)val;
+	DPRINTF(("fat_next_cluster: %d => %d\n", cl, *next));
+	return 0;
+}
+
+/*
+ * Set next cluster number in FAT chain.
+ * @fmp: fat mount data
+ * @cl: previous cluster#
+ * @next: cluster# to set (can be eof)
+ */
+int
+fat_set_cluster(struct fatfsmount *fmp, u_long cl, u_long next)
+{
+	u_int offset;
+	char *buf = fmp->fat_buf;
+	int error;
+	uint16_t val, tmp;
+
+	/* Read FAT entry */
+	error = read_fat_entry(fmp, cl);
+	if (error)
+		return error;
+
+	/* Get offset in buffer. */
+	if (FAT16(fmp))
+		offset = (cl * 2) % SEC_SIZE;
+	else
+		offset = (cl * 3 / 2) % SEC_SIZE;
+
+	/* Modify FAT entry for target cluster. */
+	val = (uint16_t)(next & fmp->fat_mask);
+	if (FAT12(fmp)) {
+		tmp = *((uint16_t *)(buf + offset));
+		if (cl & 1) {
+			val <<= 4;
+			val |= (tmp & 0xf);
+		} else {
+			tmp &= 0xf000;
+			val |= tmp;
+		}
+	}
+	*((uint16_t *)(buf + offset)) = val;
+
+	/* Write FAT entry */
+	error = write_fat_entry(fmp, cl);
+	return error;
+}
+
+/*
+ * Allocate free cluster in FAT chain.
+ *
+ * @fmp: fat mount data
+ * @scan_start: cluster# to scan first. If 0, use the previous used value.
+ * @free: allocated cluster# to return
+ */
+int
+fat_alloc_cluster(struct fatfsmount *fmp, u_long scan_start, u_long *free)
+{
+	u_long cl, next;
+	int error;
+
+	if (scan_start == 0)
+		scan_start = fmp->free_scan;
+
+	DPRINTF(("fat_alloc_cluster: start=%d\n", scan_start));
+
+	cl = scan_start + 1;
+	while (cl != scan_start) {
+		error = fat_next_cluster(fmp, cl, &next);
+		if (error)
+			return error;
+		if (next == CL_FREE) {	/* free ? */
+			DPRINTF(("fat_alloc_cluster: free cluster=%d\n", cl));
+			*free = cl;
+			return 0;
+		}
+		if (++cl >= fmp->last_cluster)
+			cl = CL_FIRST;
+	}
+	return ENOSPC;		/* no space */
+}
+
+/*
+ * Deallocate needless cluster.
+ * @fmp: fat mount data
+ * @start: first cluster# of FAT chain
+ */
+int
+fat_free_clusters(struct fatfsmount *fmp, u_long start)
+{
+	int error;
+	u_long cl, next;
+
+	cl = start;
+	if (cl < CL_FIRST)
+		return EINVAL;
+
+	while (!IS_EOFCL(fmp, cl)) {
+		error = fat_next_cluster(fmp, cl, &next);
+		if (error)
+			return error;
+		error = fat_set_cluster(fmp, cl, CL_FREE);
+		if (error)
+			return error;
+		cl = next;
+	}
+	/* Clear eof */
+	error = fat_set_cluster(fmp, cl, CL_FREE);
+	if (error)
+		return error;
+	return 0;
+}
+
+/*
+ * Get the cluster# for the specific file offset.
+ *
+ * @fmp: fat mount data
+ * @start: start cluster# of file.
+ * @offset: file offset
+ * @cl: cluster# to return
+ */
+int
+fat_seek_cluster(struct fatfsmount *fmp, u_long start, u_long offset,
+		 u_long *cl)
+{
+	int error, i;
+	u_long c, target;
+
+	if (start > fmp->last_cluster)
+		return EIO;
+
+	c = start;
+	target = offset / fmp->cluster_size;
+	for (i = 0; i < target; i++) {
+		error = fat_next_cluster(fmp, c, &c);
+		if (error)
+			return error;
+		if (IS_EOFCL(fmp, c))
+			return EIO;
+	}
+	*cl = c;
+	return 0;
+}
+
+/*
+ * Expand file size.
+ *
+ * @fmp: fat mount data
+ * @cl: cluster# of target file.
+ * @size: new size of file in bytes.
+ */
+int
+fat_expand_file(struct fatfsmount *fmp, u_long cl, int size)
+{
+	int i, cl_len, alloc, error;
+	u_long next;
+
+	alloc = 0;
+	cl_len = size / fmp->cluster_size + 1;
+
+	for (i = 0; i < cl_len; i++) {
+		error = fat_next_cluster(fmp, cl, &next);
+		if (error)
+			return error;
+		if (alloc || next >= fmp->fat_eof) {
+			error = fat_alloc_cluster(fmp, cl, &next);
+			if (error)
+				return error;
+			alloc = 1;
+		}
+		if (alloc) {
+			error = fat_set_cluster(fmp, cl, next);
+			if (error)
+				return error;
+		}
+		cl = next;
+	}
+	if (alloc)
+		fat_set_cluster(fmp, cl, fmp->fat_eof);	/* add eof */
+	DPRINTF(("fat_expand_file: new size=%d\n", size));
+	return 0;
+}
+
+/*
+ * Expand directory size.
+ *
+ * @fmp: fat mount data
+ * @cl: cluster# of target directory
+ * @new_cl: cluster# for new directory to return
+ *
+ * Note: The root directory can not be expanded.
+ */
+int
+fat_expand_dir(struct fatfsmount *fmp, u_long cl, u_long *new_cl)
+{
+	int error;
+	u_long next;
+
+	/* Find last cluster number of FAT chain. */
+	while (!IS_EOFCL(fmp, cl)) {
+		error = fat_next_cluster(fmp, cl, &next);
+		if (error)
+			return error;
+		cl = next;
+	}
+
+	error = fat_alloc_cluster(fmp, cl, &next);
+	if (error)
+		return error;
+
+	error = fat_set_cluster(fmp, cl, next);
+	if (error)
+		return error;
+
+	error = fat_set_cluster(fmp, next, fmp->fat_eof);
+	if (error)
+		return error;
+
+	*new_cl = next;
+	return 0;
+}

--- a/fatfs_fat.c
+++ b/fatfs_fat.c
@@ -305,9 +305,9 @@ fat_expand_file(struct fatfsmount *fmp, __u32 cl, __u32 size)
 	__u32 next;
 
 	alloc = 0;
-	cl_len = size / fmp->cluster_size + 1;
+	cl_len = (size + fmp->cluster_size - 1) / fmp->cluster_size;
 
-	for (i = 0; i < cl_len; i++) {
+	for (i = 1; i < cl_len; i++) {
 		error = fat_next_cluster(fmp, cl, &next);
 		if (error)
 			return error;

--- a/fatfs_node.c
+++ b/fatfs_node.c
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2005-2008, Kohsuke Ohtani
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the author nor the names of any co-contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/prex.h>
+#include <sys/buf.h>
+
+#include <ctype.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "fatfs.h"
+
+/*
+ * Read directory entry to buffer, with cache.
+ */
+static int
+fat_read_dirent(struct fatfsmount *fmp, u_long sec)
+{
+	struct buf *bp;
+	int error;
+
+	if ((error = bread(fmp->dev, sec, &bp)) != 0)
+		return error;
+	memcpy(fmp->dir_buf, bp->b_data, SEC_SIZE);
+	brelse(bp);
+	return 0;
+}
+
+/*
+ * Write directory entry from buffer.
+ */
+static int
+fat_write_dirent(struct fatfsmount *fmp, u_long sec)
+{
+	struct buf *bp;
+
+	bp = getblk(fmp->dev, sec);
+	memcpy(bp->b_data, fmp->dir_buf, SEC_SIZE);
+	return bwrite(bp);
+}
+
+/*
+ * Find directory entry in specified sector.
+ * The fat vnode data is filled if success.
+ *
+ * @fmp: fatfs mount point
+ * @sec: sector#
+ * @name: file name
+ * @node: pointer to fat node
+ */
+static int
+fat_lookup_dirent(struct fatfsmount *fmp, u_long sec, char *name,
+		  struct fatfs_node *np)
+{
+	struct fat_dirent *de;
+	int error, i;
+
+	error = fat_read_dirent(fmp, sec);
+	if (error)
+		return error;
+
+	de = (struct fat_dirent *)fmp->dir_buf;
+
+	for (i = 0; i < DIR_PER_SEC; i++) {
+		/* Find specific file or directory name */
+		if (IS_EMPTY(de))
+			return ENOENT;
+		if (!IS_VOL(de) &&
+		    !fat_compare_name((char *)de->name, name)) {
+			/* Found. Fill the fat vnode data. */
+			*(&np->dirent) = *de;
+			np->sector = sec;
+			np->offset = sizeof(struct fat_dirent) * i;
+			DPRINTF(("fat_lookup_dirent: found sec=%d\n", sec));
+			return 0;
+		}
+		if (!IS_DELETED(de))
+			DPRINTF(("fat_lookup_dirent: %s\n", de->name));
+		de++;
+	}
+	return EAGAIN;
+}
+
+/*
+ * Find directory entry for specified name in directory.
+ * The fat vnode data is filled if success.
+ *
+ * @dvp: vnode for directory.
+ * @name: file name
+ * @np: pointer to fat node
+ */
+int
+fatfs_lookup_node(vnode_t dvp, char *name, struct fatfs_node *np)
+{
+	struct fatfsmount *fmp;
+	char fat_name[12];
+	u_long cl, sec;
+	int i, error;
+
+	if (name == NULL)
+		return ENOENT;
+
+	DPRINTF(("fat_lookup_denode: cl=%d name=%s\n", dvp->v_blkno, name));
+
+	fat_convert_name(name, fat_name);
+	*(fat_name + 11) = '\0';
+
+	fmp = (struct fatfsmount *)dvp->v_mount->m_data;
+	cl = dvp->v_blkno;
+	if (cl == CL_ROOT) {
+		/* Search entry in root directory */
+		for (sec = fmp->root_start; sec < fmp->data_start; sec++) {
+			error = fat_lookup_dirent(fmp, sec, fat_name, np);
+			if (error != EAGAIN)
+				return error;
+		}
+	} else {
+		/* Search entry in sub directory */
+		while (!IS_EOFCL(fmp, cl)) {
+			sec = cl_to_sec(fmp, cl);
+			for (i = 0; i < fmp->sec_per_cl; i++) {
+				error = fat_lookup_dirent(fmp, sec, fat_name,
+						   np);
+				if (error != EAGAIN)
+					return error;
+				sec++;
+			}
+			error = fat_next_cluster(fmp, cl, &cl);
+			if (error)
+				return error;
+		}
+	}
+	return ENOENT;
+}
+
+/*
+ * Get directory entry for specified index in sector.
+ * The directory entry is filled if success.
+ *
+ * @fmp: fatfs mount point
+ * @sec: sector#
+ * @target: target index
+ * @index: current index
+ * @np: pointer to fat node
+ */
+static int
+fat_get_dirent(struct fatfsmount *fmp, u_long sec, int target, int *index,
+	       struct fatfs_node *np)
+{
+	struct fat_dirent *de;
+	int error, i;
+
+	error = fat_read_dirent(fmp, sec);
+	if (error)
+		return error;
+
+	de = (struct fat_dirent *)fmp->dir_buf;
+	for (i = 0; i < DIR_PER_SEC; i++) {
+		if (IS_EMPTY(de))
+			return ENOENT;
+		if (!IS_DELETED(de) && !IS_VOL(de)) {
+			/* valid file */
+			if (*index == target) {
+				*(&np->dirent) = *de;
+				np->sector = sec;
+				np->offset = sizeof(struct fat_dirent) * i;
+				DPRINTF(("fat_get_dirent: found index=%d\n", *index));
+				return 0;
+			}
+			(*index)++;
+		}
+		DPRINTF(("fat_get_dirent: %s\n", de->name));
+		de++;
+	}
+	return EAGAIN;
+}
+
+/*
+ * Get directory entry for specified index.
+ *
+ * @dvp: vnode for directory.
+ * @index: index of the entry
+ * @np: pointer to fat node
+ */
+int
+fatfs_get_node(vnode_t dvp, int index, struct fatfs_node *np)
+{
+	struct fatfsmount *fmp;
+	u_long cl, sec;
+	int i, cur_index, error;
+
+	fmp = (struct fatfsmount *)dvp->v_mount->m_data;
+	cl = dvp->v_blkno;
+	cur_index = 0;
+
+	DPRINTF(("fatfs_get_node: index=%d\n", index));
+
+	if (cl == CL_ROOT) {
+		/* Get entry from the root directory */
+		for (sec = fmp->root_start; sec < fmp->data_start; sec++) {
+			error = fat_get_dirent(fmp, sec, index, &cur_index, np);
+			if (error != EAGAIN)
+				return error;
+		}
+	} else {
+		/* Get entry from the sub directory */
+		while (!IS_EOFCL(fmp, cl)) {
+			sec = cl_to_sec(fmp, cl);
+			for (i = 0; i < fmp->sec_per_cl; i++) {
+				error = fat_get_dirent(fmp, sec, index,
+						     &cur_index, np);
+				if (error != EAGAIN)
+					return error;
+				sec++;
+			}
+			error = fat_next_cluster(fmp, cl, &cl);
+			if (error)
+				return error;
+		}
+	}
+	return ENOENT;
+}
+
+/*
+ * Find empty directory entry and put new entry on it.
+ *
+ * @fmp: fatfs mount point
+ * @sec: sector#
+ * @np: pointer to fat node
+ */
+static int
+fat_add_dirent(struct fatfsmount *fmp, u_long sec, struct fatfs_node *np)
+{
+	struct fat_dirent *de;
+	int error, i;
+
+	error = fat_read_dirent(fmp, sec);
+	if (error)
+		return error;
+
+	de = (struct fat_dirent *)fmp->dir_buf;
+	for (i = 0; i < DIR_PER_SEC; i++) {
+		if (IS_DELETED(de) || IS_EMPTY(de))
+			goto found;
+		DPRINTF(("fat_add_dirent: scan %s\n", de->name));
+		de++;
+	}
+	return ENOENT;
+
+ found:
+	DPRINTF(("fat_add_dirent: found. sec=%d\n", sec));
+	memcpy(de, &np->dirent, sizeof(struct fat_dirent));
+	error = fat_write_dirent(fmp, sec);
+	return error;
+}
+
+/*
+ * Find empty directory entry and put new entry on it.
+ * This search is done only in directory of specified cluster.
+ * @dvp: vnode for directory.
+ * @np: pointer to fat node
+ */
+int
+fatfs_add_node(vnode_t dvp, struct fatfs_node *np)
+{
+	struct fatfsmount *fmp;
+	u_long cl, sec;
+	int i, error;
+	u_long next;
+
+	fmp = (struct fatfsmount *)dvp->v_mount->m_data;
+	cl = dvp->v_blkno;
+
+	DPRINTF(("fatfs_add_node: cl=%d\n", cl));
+
+	if (cl == CL_ROOT) {
+		/* Add entry in root directory */
+		for (sec = fmp->root_start; sec < fmp->data_start; sec++) {
+			error = fat_add_dirent(fmp, sec, np);
+			if (error != ENOENT)
+				return error;
+		}
+	} else {
+		/* Search entry in sub directory */
+		while (!IS_EOFCL(fmp, cl)) {
+			sec = cl_to_sec(fmp, cl);
+			for (i = 0; i < fmp->sec_per_cl; i++) {
+				error = fat_add_dirent(fmp, sec, np);
+				if (error != ENOENT)
+					return error;
+				sec++;
+			}
+			error = fat_next_cluster(fmp, cl, &next);
+			if (error)
+				return error;
+			cl = next;
+		}
+		/* No entry found, add one more free cluster for directory */
+		DPRINTF(("fatfs_add_node: expand dir\n"));
+		error = fat_expand_dir(fmp, cl, &next);
+		if (error)
+			return error;
+
+		/* Initialize free cluster. */
+		memset(fmp->dir_buf, 0, SEC_SIZE);
+		sec = cl_to_sec(fmp, next);
+		for (i = 0; i < fmp->sec_per_cl; i++) {
+			error = fat_write_dirent(fmp, sec);
+			if (error)
+				return error;
+			sec++;
+		}
+		/* Try again */
+		sec = cl_to_sec(fmp, next);
+		error = fat_add_dirent(fmp, sec, np);
+		return error;
+	}
+	return ENOENT;
+}
+
+/*
+ * Put directory entry.
+ * @fmp: fat mount data
+ * @np: pointer to fat node
+ */
+int
+fatfs_put_node(struct fatfsmount *fmp, struct fatfs_node *np)
+{
+	int error;
+
+	error = fat_read_dirent(fmp, np->sector);
+	if (error)
+		return error;
+
+	memcpy(fmp->dir_buf + np->offset, &np->dirent,
+	       sizeof(struct fat_dirent));
+
+	error = fat_write_dirent(fmp, np->sector);
+	return error;
+}
+

--- a/fatfs_node.c
+++ b/fatfs_node.c
@@ -219,9 +219,28 @@ fatfs_get_node(struct vnode *dvp, int index, struct fatfs_node *np)
 	DPRINTF(("fatfs_get_node: index=%d\n", index));
 
 	if (cl == CL_ROOT) {
+		if (index == 0) {
+			memcpy(np->dirent.name, ".          ", 11);
+			np->dirent.attr = FA_SUBDIR;
+			np->dirent.cluster = cl;
+			np->dirent.time = 0;
+			np->dirent.date = 0;
+			/* These fatfs nodes do not exist on disk! */
+			np->sector = __U32_MAX;
+			return 0;
+		}
+		if (index == 1) {
+			memcpy(np->dirent.name, "..         ", 11);
+			np->dirent.attr = FA_SUBDIR;
+			np->dirent.cluster = cl;
+			np->dirent.time = 0;
+			np->dirent.date = 0;
+			np->sector = __U32_MAX;
+			return 0;
+		}
 		/* Get entry from the root directory */
 		for (sec = fmp->root_start; sec < fmp->data_start; sec++) {
-			error = fat_get_dirent(fmp, sec, index, &cur_index, np);
+			error = fat_get_dirent(fmp, sec, index - 2, &cur_index, np);
 			if (error != EAGAIN)
 				return error;
 		}

--- a/fatfs_subr.c
+++ b/fatfs_subr.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2005-2008, Kohsuke Ohtani
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the author nor the names of any co-contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/prex.h>
+
+#include <ctype.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "fatfs.h"
+
+
+/*
+ * Convert file name to 8.3 format
+ *  Ex. "foo.bar" => "foo     bar"
+ */
+void
+fat_convert_name(char *org, char *name)
+{
+	int i;
+
+	memset(name, (int)' ', 11);
+	for (i = 0; i <= 11; i++) {
+		if (!*org)
+			break;
+		if (*org == '/')
+			break;
+		if (*org == '.') {
+			i = 7;
+			org++;
+			continue;
+		}
+		*(name + i) = *org;
+		org++;
+	}
+}
+
+/*
+ * Restore file name to normal format
+ *  Ex. "foo     bar" => "foo.bar"
+ */
+void
+fat_restore_name(char *org, char *name)
+{
+	int i;
+
+	memset(name, 0, 13);
+	for (i = 0; i < 8; i++) {
+		if (*org != ' ')
+			*name++ = *org;
+		org++;
+	}
+	if (*org != ' ')
+		*name++ = '.';
+	for (i = 0; i < 3; i++) {
+		if (*org != ' ')
+			*name++ = *org;
+		org++;
+	}
+}
+
+/*
+ * Compare 2 file names.
+ *
+ * Return 0 if it matches.
+ */
+int
+fat_compare_name(char *n1, char *n2)
+{
+	int i;
+
+	for (i = 0; i < 11; i++, n1++, n2++) {
+		if (toupper((int)*n1) != toupper((int)*n2))
+			return -1;
+	}
+	return 0;
+}
+
+/*
+ * Check specified name is valid as FAT file name.
+ * Return true if valid.
+ */
+int
+fat_valid_name(char *name)
+{
+	static char invalid_char[] = "*?<>|\"+=,;[] \345";
+	int len = 0;
+
+	/* . or .. */
+	if (*name == '.') {
+		name++;
+		if (*name == '.')
+			name++;
+		return (*(name + 1) == '\0') ? 1 : 0;
+	}
+	/* First char must be alphabet or numeric */
+	if (!isalnum((int)*name))
+		return 0;
+	while (*name != '\0') {
+		if (strchr(invalid_char, *name))
+			return 0;
+		if (*name == '.')
+			break;	/* Start of extension */
+		if (++len > 8)
+			return 0;	/* Too long name */
+		name++;
+	}
+	if (*name == '\0')
+		return 1;
+	name++;
+	if (*name == '\0')	/* Empty extension */
+		return 1;
+	len = 0;
+	while (*name != '\0') {
+		if (strchr(invalid_char, *name))
+			return 0;
+		if (*name == '.')
+			return 0;	/* Second extention */
+		if (++len > 3)
+			return 0;	/* Too long name */
+		name++;
+	}
+	return 1;
+}
+
+/*
+ * mode -> attribute
+ */
+void
+fat_mode_to_attr(mode_t mode, u_char *attr)
+{
+
+	*attr = 0;
+	if (!(mode & S_IWRITE))
+		*attr |= FA_RDONLY;
+	if (!(mode & S_IREAD))
+		*attr |= FA_HIDDEN;
+	if (S_ISDIR(mode))
+		*attr |= FA_SUBDIR;
+}
+
+/*
+ * attribute -> mode
+ */
+void
+fat_attr_to_mode(u_char attr, mode_t *mode)
+{
+
+	if (attr & FA_RDONLY)
+		*mode =
+		    S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH |
+		    S_IXOTH;
+	else
+		*mode = S_IRWXU | S_IRWXG | S_IRWXO;
+
+	if (attr & FA_SUBDIR)
+		*mode |= S_IFDIR;
+	else
+		*mode |= S_IFREG;
+}

--- a/fatfs_subr.c
+++ b/fatfs_subr.c
@@ -26,14 +26,10 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-
-#include <sys/prex.h>
+#define _GNU_SOURCE
 
 #include <ctype.h>
 #include <string.h>
-#include <unistd.h>
-#include <errno.h>
-#include <stdlib.h>
 
 #include "fatfs.h"
 
@@ -155,7 +151,7 @@ fat_valid_name(char *name)
  * mode -> attribute
  */
 void
-fat_mode_to_attr(mode_t mode, u_char *attr)
+fat_mode_to_attr(mode_t mode, unsigned char *attr)
 {
 
 	*attr = 0;
@@ -171,7 +167,7 @@ fat_mode_to_attr(mode_t mode, u_char *attr)
  * attribute -> mode
  */
 void
-fat_attr_to_mode(u_char attr, mode_t *mode)
+fat_attr_to_mode(unsigned char attr, mode_t *mode)
 {
 
 	if (attr & FA_RDONLY)

--- a/fatfs_vfsops.c
+++ b/fatfs_vfsops.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2005-2008, Kohsuke Ohtani
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the author nor the names of any co-contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/prex.h>
+
+#include <sys/stat.h>
+#include <sys/vnode.h>
+#include <sys/file.h>
+#include <sys/mount.h>
+#include <sys/buf.h>
+
+#include <ctype.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+#include "fatfs.h"
+
+static int fatfs_mount	(mount_t mp, char *dev, int flags, void *data);
+static int fatfs_unmount(mount_t mp);
+#define fatfs_sync	((vfsop_sync_t)vfs_nullop)
+static int fatfs_vget	(mount_t mp, vnode_t vp);
+#define fatfs_statfs	((vfsop_statfs_t)vfs_nullop)
+
+/*
+ * File system operations
+ */
+struct vfsops fatfs_vfsops = {
+	fatfs_mount,		/* mount */
+	fatfs_unmount,		/* unmount */
+	fatfs_sync,		/* sync */
+	fatfs_vget,		/* vget */
+	fatfs_statfs,		/* statfs */
+	&fatfs_vnops,		/* vnops */
+};
+
+/*
+ * Read BIOS parameter block.
+ * Return 0 on sucess.
+ */
+static int
+fat_read_bpb(struct fatfsmount *fmp)
+{
+	struct fat_bpb *bpb;
+	size_t size;
+	int error;
+
+	bpb = malloc(SEC_SIZE);
+	if (bpb == NULL)
+		return ENOMEM;
+
+	/* Read boot sector (block:0) */
+	size = SEC_SIZE;
+	error = device_read(fmp->dev, bpb, &size, 0);
+	if (error) {
+		free(bpb);
+		return error;
+	}
+	if (bpb->bytes_per_sector != SEC_SIZE) {
+		DPRINTF(("fatfs: invalid sector size\n"));
+		free(bpb);
+		return EINVAL;
+	}
+
+	/* Build FAT mount data */
+	fmp->fat_start = bpb->hidden_sectors + bpb->reserved_sectors;
+	fmp->root_start = fmp->fat_start +
+		(bpb->num_of_fats * bpb->sectors_per_fat);
+	fmp->data_start =
+		fmp->root_start + (bpb->root_entries / DIR_PER_SEC);
+	fmp->sec_per_cl = bpb->sectors_per_cluster;
+	fmp->cluster_size = bpb->sectors_per_cluster * SEC_SIZE;
+	fmp->last_cluster = (bpb->total_sectors - fmp->data_start) /
+		bpb->sectors_per_cluster + CL_FIRST;
+	fmp->free_scan = CL_FIRST;
+
+	if (!strncmp((const char *)bpb->file_sys_id, "FAT12   ", 8)) {
+		fmp->fat_type = 12;
+		fmp->fat_mask = FAT12_MASK;
+		fmp->fat_eof = CL_EOF & FAT12_MASK;
+	} else if (!strncmp((const char *)bpb->file_sys_id, "FAT16   ", 8)) {
+		fmp->fat_type = 16;
+		fmp->fat_mask = FAT16_MASK;
+		fmp->fat_eof = CL_EOF & FAT16_MASK;
+	} else {
+		/* FAT32 is not supported now! */
+		DPRINTF(("fatfs: invalid FAT type\n"));
+		free(bpb);
+		return EINVAL;
+	}
+	free(bpb);
+
+	DPRINTF(("----- FAT info -----\n"));
+	DPRINTF(("drive:%x\n", (int)bpb->physical_drive));
+	DPRINTF(("total_sectors:%d\n", (int)bpb->total_sectors));
+	DPRINTF(("heads       :%d\n", (int)bpb->heads));
+	DPRINTF(("serial      :%x\n", (int)bpb->serial_no));
+	DPRINTF(("cluster size:%u sectors\n", (int)fmp->sec_per_cl));
+	DPRINTF(("fat_type    :FAT%u\n", (int)fmp->fat_type));
+	DPRINTF(("fat_eof     :0x%x\n\n", (int)fmp->fat_eof));
+	return 0;
+}
+
+/*
+ * Mount file system.
+ */
+static int
+fatfs_mount(mount_t mp, char *dev, int flags, void *data)
+{
+	struct fatfsmount *fmp;
+	vnode_t vp;
+	int error = 0;
+
+	DPRINTF(("fatfs_mount device=%s\n", dev));
+
+	fmp = malloc(sizeof(struct fatfsmount));
+	if (fmp == NULL)
+		return ENOMEM;
+
+	fmp->dev = mp->m_dev;
+	if (fat_read_bpb(fmp) != 0)
+		goto err1;
+
+	error = ENOMEM;
+	fmp->io_buf = malloc(fmp->sec_per_cl * SEC_SIZE);
+	if (fmp->io_buf == NULL)
+		goto err1;
+
+	fmp->fat_buf = malloc(SEC_SIZE * 2);
+	if (fmp->fat_buf == NULL)
+		goto err2;
+
+	fmp->dir_buf = malloc(SEC_SIZE);
+	if (fmp->dir_buf == NULL)
+		goto err3;
+
+	mutex_init(&fmp->lock);
+	mp->m_data = fmp;
+	vp = mp->m_root;
+	vp->v_blkno = CL_ROOT;
+	return 0;
+ err3:
+	free(fmp->fat_buf);
+ err2:
+	free(fmp->io_buf);
+ err1:
+	free(fmp);
+	return error;
+}
+
+/*
+ * Unmount the file system.
+ */
+static int
+fatfs_unmount(mount_t mp)
+{
+	struct fatfsmount *fmp;
+
+	fmp = mp->m_data;
+	free(fmp->dir_buf);
+	free(fmp->fat_buf);
+	free(fmp->io_buf);
+	mutex_destroy(&fmp->lock);
+	free(fmp);
+	return 0;
+}
+
+/*
+ * Prepare the FAT specific node and fill the vnode.
+ */
+static int
+fatfs_vget(mount_t mp, vnode_t vp)
+{
+	struct fatfs_node *np;
+
+	np = malloc(sizeof(struct fatfs_node));
+	if (np == NULL)
+		return ENOMEM;
+	vp->v_data = np;
+	return 0;
+}
+

--- a/fatfs_vnops.c
+++ b/fatfs_vnops.c
@@ -1,0 +1,719 @@
+/*
+ * Copyright (c) 2005-2008, Kohsuke Ohtani
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the author nor the names of any co-contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/prex.h>
+
+#include <sys/vnode.h>
+#include <sys/file.h>
+#include <sys/mount.h>
+#include <sys/dirent.h>
+#include <sys/buf.h>
+
+#include <ctype.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+#include "fatfs.h"
+
+/*
+ *  Time bits: 15-11 hours (0-23), 10-5 min, 4-0 sec /2
+ *  Date bits: 15-9 year - 1980, 8-5 month, 4-0 day
+ */
+#define TEMP_DATE   0x3021
+#define TEMP_TIME   0
+
+#define fatfs_open	((vnop_open_t)vop_nullop)
+#define fatfs_close	((vnop_close_t)vop_nullop)
+static int fatfs_read	(vnode_t, file_t, void *, size_t, size_t *);
+static int fatfs_write	(vnode_t, file_t, void *, size_t, size_t *);
+#define fatfs_seek	((vnop_seek_t)vop_nullop)
+#define fatfs_ioctl	((vnop_ioctl_t)vop_einval)
+#define fatfs_fsync	((vnop_fsync_t)vop_nullop)
+static int fatfs_readdir(vnode_t, file_t, struct dirent *);
+static int fatfs_lookup	(vnode_t, char *, vnode_t);
+static int fatfs_create	(vnode_t, char *, mode_t);
+static int fatfs_remove	(vnode_t, vnode_t, char *);
+static int fatfs_rename	(vnode_t, vnode_t, char *, vnode_t, vnode_t, char *);
+static int fatfs_mkdir	(vnode_t, char *, mode_t);
+static int fatfs_rmdir	(vnode_t, vnode_t, char *);
+static int fatfs_getattr(vnode_t, struct vattr *);
+static int fatfs_setattr(vnode_t, struct vattr *);
+static int fatfs_inactive(vnode_t);
+static int fatfs_truncate(vnode_t, off_t);
+
+/*
+ * vnode operations
+ */
+struct vnops fatfs_vnops = {
+	fatfs_open,		/* open */
+	fatfs_close,		/* close */
+	fatfs_read,		/* read */
+	fatfs_write,		/* write */
+	fatfs_seek,		/* seek */
+	fatfs_ioctl,		/* ioctl */
+	fatfs_fsync,		/* fsync */
+	fatfs_readdir,		/* readdir */
+	fatfs_lookup,		/* lookup */
+	fatfs_create,		/* create */
+	fatfs_remove,		/* remove */
+	fatfs_rename,		/* remame */
+	fatfs_mkdir,		/* mkdir */
+	fatfs_rmdir,		/* rmdir */
+	fatfs_getattr,		/* getattr */
+	fatfs_setattr,		/* setattr */
+	fatfs_inactive,		/* inactive */
+	fatfs_truncate,		/* truncate */
+};
+
+/*
+ * Read one cluster to buffer.
+ */
+static int
+fat_read_cluster(struct fatfsmount *fmp, u_long cluster)
+{
+	u_long sec;
+	size_t size;
+
+	sec = cl_to_sec(fmp, cluster);
+	size = fmp->sec_per_cl * SEC_SIZE;
+	return device_read(fmp->dev, fmp->io_buf, &size, sec);
+}
+
+/*
+ * Write one cluster from buffer.
+ */
+static int
+fat_write_cluster(struct fatfsmount *fmp, u_long cluster)
+{
+	u_long sec;
+	size_t size;
+
+	sec = cl_to_sec(fmp, cluster);
+	size = fmp->sec_per_cl * SEC_SIZE;
+	return device_write(fmp->dev, fmp->io_buf, &size, sec);
+}
+
+/*
+ * Lookup vnode for the specified file/directory.
+ * The vnode data will be set properly.
+ */
+static int
+fatfs_lookup(vnode_t dvp, char *name, vnode_t vp)
+{
+	struct fatfsmount *fmp;
+	struct fat_dirent *de;
+	struct fatfs_node *np;
+	int error;
+
+	if (*name == '\0')
+		return ENOENT;
+
+	fmp = vp->v_mount->m_data;
+	mutex_lock(&fmp->lock);
+
+	DPRINTF(("fatfs_lookup: name=%s\n", name));
+
+	np = vp->v_data;
+	error = fatfs_lookup_node(dvp, name, np);
+	if (error) {
+		DPRINTF(("fatfs_lookup: failed!! name=%s\n", name));
+		mutex_unlock(&fmp->lock);
+		return error;
+	}
+	de = &np->dirent;
+	vp->v_type = IS_DIR(de) ? VDIR : VREG;
+	fat_attr_to_mode(de->attr, &vp->v_mode);
+	vp->v_mode = ALLPERMS;
+	vp->v_size = de->size;
+	vp->v_blkno = de->cluster;
+
+	DPRINTF(("fatfs_lookup: cl=%d\n", de->cluster));
+	mutex_unlock(&fmp->lock);
+	return 0;
+}
+
+static int
+fatfs_read(vnode_t vp, file_t fp, void *buf, size_t size, size_t *result)
+{
+	struct fatfsmount *fmp;
+	int nr_read, nr_copy, buf_pos, error;
+	u_long cl, file_pos;
+
+	DPRINTF(("fatfs_read: vp=%x\n", vp));
+
+	*result = 0;
+	fmp = vp->v_mount->m_data;
+
+	if (vp->v_type == VDIR)
+		return EISDIR;
+	if (vp->v_type != VREG)
+		return EINVAL;
+
+	/* Check if current file position is already end of file. */
+	file_pos = fp->f_offset;
+	if (file_pos >= vp->v_size)
+		return 0;
+
+	mutex_lock(&fmp->lock);
+
+	/* Get the actual read size. */
+	if (vp->v_size - file_pos < size)
+		size = vp->v_size - file_pos;
+
+	/* Seek to the cluster for the file offset */
+	error = fat_seek_cluster(fmp, vp->v_blkno, file_pos, &cl);
+	if (error)
+		goto out;
+
+	/* Read and copy data */
+	nr_read = 0;
+	buf_pos = file_pos % fmp->cluster_size;
+	do {
+		if (fat_read_cluster(fmp, cl)) {
+			error = EIO;
+			goto out;
+		}
+
+		nr_copy = fmp->cluster_size;
+		if (buf_pos > 0)
+			nr_copy -= buf_pos;
+		if (buf_pos + size < fmp->cluster_size)
+			nr_copy = size;
+		memcpy(buf, fmp->io_buf + buf_pos, nr_copy);
+
+		file_pos += nr_copy;
+		nr_read += nr_copy;
+		size -= nr_copy;
+		if (size <= 0)
+			break;
+
+		error = fat_next_cluster(fmp, cl, &cl);
+		if (error)
+			goto out;
+
+		buf = (void *)((u_long)buf + nr_copy);
+		buf_pos = 0;
+	} while (!IS_EOFCL(fmp, cl));
+
+	fp->f_offset = file_pos;
+	*result = nr_read;
+	error = 0;
+ out:
+	mutex_unlock(&fmp->lock);
+	return error;
+}
+
+static int
+fatfs_write(vnode_t vp, file_t fp, void *buf, size_t size, size_t *result)
+{
+	struct fatfsmount *fmp;
+	struct fatfs_node *np;
+	struct fat_dirent *de;
+	int nr_copy, nr_write, buf_pos, i, cl_size, error;
+	u_long file_pos, end_pos;
+	u_long cl;
+
+	DPRINTF(("fatfs_write: vp=%x\n", vp));
+
+	*result = 0;
+	fmp = vp->v_mount->m_data;
+
+	if (vp->v_type == VDIR)
+		return EISDIR;
+	if (vp->v_type != VREG)
+		return EINVAL;
+
+	mutex_lock(&fmp->lock);
+
+	/* Check if file position exceeds the end of file. */
+	end_pos = vp->v_size;
+	file_pos = (fp->f_flags & O_APPEND) ? end_pos : fp->f_offset;
+	if (file_pos + size > end_pos) {
+		/* Expand the file size before writing to it */
+		end_pos = file_pos + size;
+		error = fat_expand_file(fmp, vp->v_blkno, end_pos);
+		if (error) {
+			error = EIO;
+			goto out;
+		}
+
+		/* Update directory entry */
+		np = vp->v_data;
+		de = &np->dirent;
+		de->size = end_pos;
+		error = fatfs_put_node(fmp, np);
+		if (error)
+			goto out;
+		vp->v_size = end_pos;
+	}
+
+	/* Seek to the cluster for the file offset */
+	error = fat_seek_cluster(fmp, vp->v_blkno, file_pos, &cl);
+	if (error)
+		goto out;
+
+	buf_pos = file_pos % fmp->cluster_size;
+	cl_size = size / fmp->cluster_size + 1;
+	nr_write = 0;
+	i = 0;
+	do {
+		/* First and last cluster must be read before write */
+		if (i == 0 || i == cl_size) {
+			if (fat_read_cluster(fmp, cl)) {
+				error = EIO;
+				goto out;
+			}
+		}
+		nr_copy = fmp->cluster_size;
+		if (buf_pos > 0)
+			nr_copy -= buf_pos;
+		if (buf_pos + size < fmp->cluster_size)
+			nr_copy = size;
+		memcpy(fmp->io_buf + buf_pos, buf, nr_copy);
+
+		if (fat_write_cluster(fmp, cl)) {
+			error = EIO;
+			goto out;
+		}
+		file_pos += nr_copy;
+		nr_write += nr_copy;
+		size -= nr_copy;
+		if (size <= 0)
+			break;
+
+		error = fat_next_cluster(fmp, cl, &cl);
+		if (error)
+			goto out;
+
+		buf = (void *)((u_long)buf + nr_copy);
+		buf_pos = 0;
+		i++;
+	} while (!IS_EOFCL(fmp, cl));
+
+	fp->f_offset = file_pos;
+
+	/*
+	 * XXX: Todo!
+	 *    de.time = ?
+	 *    de.date = ?
+	 *    if (dirent_set(fp, &de))
+	 *        return EIO;
+	 */
+	*result = nr_write;
+	error = 0;
+ out:
+	mutex_unlock(&fmp->lock);
+	return error;
+}
+
+static int
+fatfs_readdir(vnode_t vp, file_t fp, struct dirent *dir)
+{
+	struct fatfsmount *fmp;
+	struct fatfs_node np;
+	struct fat_dirent *de;
+	int error;
+
+	fmp = vp->v_mount->m_data;
+	mutex_lock(&fmp->lock);
+
+	error = fatfs_get_node(vp, fp->f_offset, &np);
+	if (error)
+		goto out;
+	de = &np.dirent;
+	fat_restore_name((char *)&de->name, dir->d_name);
+
+	if (de->attr & FA_SUBDIR)
+		dir->d_type = DT_DIR;
+	else if (de->attr & FA_DEVICE)
+		dir->d_type = DT_BLK;
+	else
+		dir->d_type = DT_REG;
+
+	dir->d_fileno = fp->f_offset;
+	dir->d_namlen = strlen(dir->d_name);
+
+	fp->f_offset++;
+	error = 0;
+ out:
+	mutex_unlock(&fmp->lock);
+	return error;
+}
+
+/*
+ * Create empty file.
+ */
+static int
+fatfs_create(vnode_t dvp, char *name, mode_t mode)
+{
+	struct fatfsmount *fmp;
+	struct fatfs_node np;
+	struct fat_dirent *de;
+	u_long cl;
+	int error;
+
+	DPRINTF(("fatfs_create: %s\n", name));
+
+	if (!S_ISREG(mode))
+		return EINVAL;
+
+	if (!fat_valid_name(name))
+		return EINVAL;
+
+	fmp = dvp->v_mount->m_data;
+	mutex_lock(&fmp->lock);
+
+	/* Allocate free cluster for new file. */
+	error = fat_alloc_cluster(fmp, 0, &cl);
+	if (error)
+		goto out;
+
+	de = &np.dirent;
+	memset(de, 0, sizeof(struct fat_dirent));
+	fat_convert_name(name, (char *)de->name);
+	de->cluster = cl;
+	de->time = TEMP_TIME;
+	de->date = TEMP_DATE;
+	fat_mode_to_attr(mode, &de->attr);
+	error = fatfs_add_node(dvp, &np);
+	if (error)
+		goto out;
+	error = fat_set_cluster(fmp, cl, fmp->fat_eof);
+ out:
+	mutex_unlock(&fmp->lock);
+	return error;
+}
+
+static int
+fatfs_remove(vnode_t dvp, vnode_t vp, char *name)
+{
+	struct fatfsmount *fmp;
+	struct fatfs_node np;
+	struct fat_dirent *de;
+	int error;
+
+	if (*name == '\0')
+		return ENOENT;
+
+	fmp = dvp->v_mount->m_data;
+	mutex_lock(&fmp->lock);
+
+	error = fatfs_lookup_node(dvp, name, &np);
+	if (error)
+		goto out;
+	de = &np.dirent;
+	if (IS_DIR(de)) {
+		error = EISDIR;
+		goto out;
+	}
+	if (!IS_FILE(de)) {
+		error = EPERM;
+		goto out;
+	}
+
+	/* Remove clusters */
+	error = fat_free_clusters(fmp, de->cluster);
+	if (error)
+		goto out;
+
+	/* remove directory */
+	de->name[0] = 0xe5;
+	error = fatfs_put_node(fmp, &np);
+ out:
+	mutex_unlock(&fmp->lock);
+	return error;
+}
+
+static int
+fatfs_rename(vnode_t dvp1, vnode_t vp1, char *name1,
+	     vnode_t dvp2, vnode_t vp2, char *name2)
+{
+	struct fatfsmount *fmp;
+	struct fatfs_node np1;
+	struct fat_dirent *de1, *de2;
+	int error;
+
+	fmp = dvp1->v_mount->m_data;
+	mutex_lock(&fmp->lock);
+
+	error = fatfs_lookup_node(dvp1, name1, &np1);
+	if (error)
+		goto out;
+	de1 = &np1.dirent;
+
+	if (IS_FILE(de1)) {
+		/* Remove destination file, first */
+		error = fatfs_remove(dvp2, vp1, name2);
+		if (error == EIO)
+			goto out;
+
+		/* Change file name of directory entry */
+		fat_convert_name(name2, (char *)de1->name);
+
+		/* Same directory ? */
+		if (dvp1 == dvp2) {
+			/* Change the name of existing file */
+			error = fatfs_put_node(fmp, &np1);
+			if (error)
+				goto out;
+		} else {
+			/* Create new directory entry */
+			error = fatfs_add_node(dvp2, &np1);
+			if (error)
+				goto out;
+
+			/* Remove souce file */
+			error = fatfs_remove(dvp1, vp2, name1);
+			if (error)
+				goto out;
+		}
+	} else {
+
+		/* remove destination directory */
+		error = fatfs_rmdir(dvp2, NULL, name2);
+		if (error == EIO)
+			goto out;
+
+		/* Change file name of directory entry */
+		fat_convert_name(name2, (char *)de1->name);
+
+		/* Same directory ? */
+		if (dvp1 == dvp2) {
+			/* Change the name of existing directory */
+			error = fatfs_put_node(fmp, &np1);
+			if (error)
+				goto out;
+		} else {
+			/* Create new directory entry */
+			error = fatfs_add_node(dvp2, &np1);
+			if (error)
+				goto out;
+
+			/* Update "." and ".." for renamed directory */
+			if (fat_read_cluster(fmp, de1->cluster)) {
+				error = EIO;
+				goto out;
+			}
+
+			de2 = (struct fat_dirent *)fmp->io_buf;
+			de2->cluster = de1->cluster;
+			de2->time = TEMP_TIME;
+			de2->date = TEMP_DATE;
+			de2++;
+			de2->cluster = dvp2->v_blkno;
+			de2->time = TEMP_TIME;
+			de2->date = TEMP_DATE;
+
+			if (fat_write_cluster(fmp, de1->cluster)) {
+				error = EIO;
+				goto out;
+			}
+
+			/* Remove souce directory */
+			error = fatfs_rmdir(dvp1, NULL, name1);
+			if (error)
+				goto out;
+		}
+	}
+ out:
+	mutex_unlock(&fmp->lock);
+	return error;
+}
+
+static int
+fatfs_mkdir(vnode_t dvp, char *name, mode_t mode)
+{
+	struct fatfsmount *fmp;
+	struct fatfs_node np;
+	struct fat_dirent *de;
+	u_long cl;
+	int error;
+
+	if (!S_ISDIR(mode))
+		return EINVAL;
+
+	if (!fat_valid_name(name))
+		return ENOTDIR;
+
+	fmp = dvp->v_mount->m_data;
+	mutex_lock(&fmp->lock);
+
+	/* Allocate free cluster for directory data */
+	error = fat_alloc_cluster(fmp, 0, &cl);
+	if (error)
+		goto out;
+
+	memset(&np, 0, sizeof(struct fatfs_node));
+	de = &np.dirent;
+	fat_convert_name(name, (char *)&de->name);
+	de->cluster = cl;
+	de->time = TEMP_TIME;
+	de->date = TEMP_DATE;
+	fat_mode_to_attr(mode, &de->attr);
+	error = fatfs_add_node(dvp, &np);
+	if (error)
+		goto out;
+
+	/* Initialize "." and ".." for new directory */
+	memset(fmp->io_buf, 0, fmp->cluster_size);
+
+	de = (struct fat_dirent *)fmp->io_buf;
+	memcpy(de->name, ".          ", 11);
+	de->attr = FA_SUBDIR;
+	de->cluster = cl;
+	de->time = TEMP_TIME;
+	de->date = TEMP_DATE;
+	de++;
+	memcpy(de->name, "..         ", 11);
+	de->attr = FA_SUBDIR;
+	de->cluster = dvp->v_blkno;
+	de->time = TEMP_TIME;
+	de->date = TEMP_DATE;
+
+	if (fat_write_cluster(fmp, cl)) {
+		error = EIO;
+		goto out;
+	}
+	/* Add eof */
+	error = fat_set_cluster(fmp, cl, fmp->fat_eof);
+ out:
+	mutex_unlock(&fmp->lock);
+	return error;
+}
+
+/*
+ * remove can be done only with empty directory
+ */
+static int
+fatfs_rmdir(vnode_t dvp, vnode_t vp, char *name)
+{
+	struct fatfsmount *fmp;
+	struct fatfs_node np;
+	struct fat_dirent *de;
+	int error;
+
+	if (*name == '\0')
+		return ENOENT;
+
+	fmp = dvp->v_mount->m_data;
+	mutex_lock(&fmp->lock);
+
+	error = fatfs_lookup_node(dvp, name, &np);
+	if (error)
+		goto out;
+
+	de = &np.dirent;
+	if (!IS_DIR(de)) {
+		error = ENOTDIR;
+		goto out;
+	}
+
+	/* Remove clusters */
+	error = fat_free_clusters(fmp, de->cluster);
+	if (error)
+		goto out;
+
+	/* remove directory */
+	de->name[0] = 0xe5;
+
+	error = fatfs_put_node(fmp, &np);
+ out:
+	mutex_unlock(&fmp->lock);
+	return error;
+}
+
+static int
+fatfs_getattr(vnode_t vp, struct vattr *vap)
+{
+	/* XXX */
+	return 0;
+}
+
+static int
+fatfs_setattr(vnode_t vp, struct vattr *vap)
+{
+	/* XXX */
+	return 0;
+}
+
+
+static int
+fatfs_inactive(vnode_t vp)
+{
+
+	free(vp->v_data);
+	return 0;
+}
+
+static int
+fatfs_truncate(vnode_t vp, off_t length)
+{
+	struct fatfsmount *fmp;
+	struct fatfs_node *np;
+	struct fat_dirent *de;
+	int error;
+
+	fmp = vp->v_mount->m_data;
+	mutex_lock(&fmp->lock);
+
+	np = vp->v_data;
+	de = &np->dirent;
+
+	if (length == 0) {
+		/* Remove clusters */
+		error = fat_free_clusters(fmp, de->cluster);
+		if (error)
+			goto out;
+	} else if (length > vp->v_size) {
+		error = fat_expand_file(fmp, vp->v_blkno, length);
+		if (error) {
+			error = EIO;
+			goto out;
+		}
+	}
+
+	/* Update directory entry */
+	de->size = length;
+	error = fatfs_put_node(fmp, np);
+	if (error)
+		goto out;
+	vp->v_size = length;
+ out:
+	mutex_unlock(&fmp->lock);
+	return error;
+}
+
+int
+fatfs_init(void)
+{
+	return 0;
+}

--- a/fatfs_vnops.c
+++ b/fatfs_vnops.c
@@ -199,7 +199,7 @@ fatfs_read(struct vnode *vp, struct vfscore_file *fp, struct uio *uio,
 	struct fatfs_node *np;
 	void *buf;
 
-	DPRINTF(("fatfs_read: vp=%x\n", vp));
+	DPRINTF(("fatfs_read: vp=%p\n", vp));
 
 	fmp = vp->v_mount->m_data;
 
@@ -289,7 +289,7 @@ fatfs_write(struct vnode *vp, struct uio *uio, int ioflag __unused)
 	__u32 file_pos, end_pos;
 	__u32 cl;
 
-	DPRINTF(("fatfs_write: vp=%x\n", vp));
+	DPRINTF(("fatfs_write: vp=%p\n", vp));
 
 	fmp = vp->v_mount->m_data;
 	np = vp->v_data;

--- a/fatfs_vnops.c
+++ b/fatfs_vnops.c
@@ -187,7 +187,7 @@ fatfs_lookup(struct vnode *dvp, char *name, struct vnode **vpp)
 }
 
 static int
-fatfs_read(struct vnode *vp, struct vfscore_file *fp, struct uio *uio,
+fatfs_read(struct vnode *vp, struct vfscore_file *fp __unused, struct uio *uio,
 	   int ioflag __unused)
 {
 	struct fatfsmount *fmp;

--- a/fatfs_vnops.c
+++ b/fatfs_vnops.c
@@ -718,9 +718,12 @@ fatfs_rmdir(struct vnode *dvp, struct vnode *vp __unused, char *name)
 }
 
 static int
-fatfs_getattr(struct vnode *vp __unused, struct vattr *vap __unused)
+fatfs_getattr(struct vnode *vp, struct vattr *vap)
 {
-	/* XXX */
+	vap->va_type = vp->v_type;
+	vap->va_mode = vp->v_mode;
+	vap->va_nodeid = vp->v_ino;
+	vap->va_size = vp->v_size;
 	return 0;
 }
 

--- a/fatfs_vnops.c
+++ b/fatfs_vnops.c
@@ -271,8 +271,6 @@ fatfs_read(struct vnode *vp, struct vfscore_file *fp, struct uio *uio,
 	iov->iov_base = buf;
 	iov->iov_len -= nr_read;
 
-	fp->f_offset = file_pos;
-
 	error = 0;
  out:
 	uk_mutex_unlock(&fmp->lock);

--- a/fatfs_vnops.c
+++ b/fatfs_vnops.c
@@ -761,6 +761,7 @@ fatfs_truncate(struct vnode *vp, off_t length)
 		error = fat_free_clusters(fmp, de->cluster);
 		if (error)
 			goto out;
+		de->cluster = CL_FREE;
 	} else if (length > vp->v_size) {
 		cl = de->cluster;
 		error = fat_expand_file(fmp, &cl, length);


### PR DESCRIPTION
This introduces a implementation with read/write support for the FAT12/16 filesystems. The implementation notably lacks support for FAT32 and long filenames. The commits also include fixes for bugs in the original implementation.

The library uses `ukblk` to access block devices and allows mounting them by using `bd<id>` as source parameter.